### PR TITLE
pin github.com/vito/go-interact to 1.0.0 so we can build from clean

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,3 +117,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+replace github.com/vito/go-interact => github.com/vito/go-interact v1.0.0


### PR DESCRIPTION
Thanks for the arm64 support, I had to add this to get it to build.