### PR TITLE
Use gmake instead of bash script to build development and release artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /cf-targets-plugin
-/release/**
+/releases/**
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /cf-targets-plugin
-/bin/**
+/release/**
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SEMVER_PATCH    ?=0
 SEMVER_PRERELEASE ?=
 SEMVER_BUILDMETA  ?=
 BUILD_DATE        :=$(shell date -u -Iseconds)
-BUILD_VCS_URL     :=$(shell git config --get remote.origin.url) 
+BUILD_VCS_URL     :=$(shell git config --get remote.origin.url)
 BUILD_VCS_ID      :=$(shell git log -n 1 --date=iso-strict-local --format="%h")
 BUILD_VCS_ID_DATE :=$(shell TZ=UTC0 git log -n 1 --date=iso-strict-local --format='%ad')
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,82 @@
+PROJECT        :=cf-targets-plugin
+GOOS           :=$(shell go env GOOS)
+GOARCH         :=$(shell go env GOARCH)
+GOMODULECMD    :=main
+RELEASE_ROOT   ?=release
+DEV_TEST_BUILD =./$(PROJECT)
+TARGETS        ?=linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
+
+SEMVER_MAJOR    ?=2
+SEMVER_MINOR    ?=1
+SEMVER_PATCH    ?=0
+SEMVER_PRERELEASE ?=
+SEMVER_BUILDMETA  ?=
+BUILD_DATE        :=$(shell date -u -Iseconds)
+BUILD_VCS_URL     :=$(shell git config --get remote.origin.url) 
+BUILD_VCS_ID      :=$(shell git log -n 1 --date=iso-strict-local --format="%h")
+BUILD_VCS_ID_DATE :=$(shell TZ=UTC0 git log -n 1 --date=iso-strict-local --format='%ad')
+
+build: SEMVER_PRERELEASE := dev
+
+GO_LDFLAGS = -ldflags="-X '$(GOMODULECMD).SemVerMajor=$(SEMVER_MAJOR)' \
+	            -X '$(GOMODULECMD).SemVerMinor=$(SEMVER_MINOR)' \
+	            -X '$(GOMODULECMD).SemVerPatch=$(SEMVER_PATCH)' \
+	            -X '$(GOMODULECMD).SemVerPrerelease=$(SEMVER_PRERELEASE)' \
+	            -X '$(GOMODULECMD).SemVerBuild=$(SEMVER_BUILDMETA)' \
+	            -X '$(GOMODULECMD).BuildDate=$(BUILD_DATE)' \
+	            -X '$(GOMODULECMD).BuildVcsUrl=$(BUILD_VCS_URL)' \
+	            -X '$(GOMODULECMD).BuildVcsId=$(BUILD_VCS_ID)' \
+		        -X '$(GOMODULECMD).BuildVcsIdDate=$(BUILD_VCS_ID_DATE)'"
+
+.PHONY: build test require-% release-% clean
+
+build:
+	CGO_ENABLED=0 go build $(GO_LDFLAGS) -o $(DEV_TEST_BUILD)
+
+require-%:
+	@ if [ "${${*}}" = "" ]; then \
+		echo "Environment variable $* not set"; \
+		exit 1; \
+	fi
+
+RELEASES := $(foreach target,$(TARGETS),release-$(target)-$(PROJECT))
+
+release-all: $(RELEASES)
+
+define build-target
+release-$(1)/$(2)-$(PROJECT): # require-VERSION
+	@echo "Building $(PROJECT) $(SEMVER_VERSION) ($(1)/$(2)) ..."
+	CGO_ENABLED=0 GOOS=$(1) GOARCH=$(2) go build -o $(RELEASE_ROOT)/$(PROJECT)-$(SEMVER_VERSION)-$(1)-$(2)$(if $(patsubst windows,,$(1)),,.exe) $(GO_LDFLAGS)
+	@ls -la $(RELEASE_ROOT)/$(PROJECT)-$(SEMVER_VERSION)-$(1)-$(2)$(if $(patsubst windows,,$(1)),,.exe)
+	@echo ""
+endef
+
+$(foreach target,$(TARGETS),$(eval $(call build-target,$(word 1, $(subst /, ,$(target))),$(word 2, $(subst /, ,$(target))))))
+
+clean:
+	rm -rf $(CAROUSEL_PATH) $(RELEASE_ROOT)/* 
+
+.DEFAULT_GOAL := release-all
+
+# test:
+#	ginkgo watch ./...
+	
+# test-ci:
+#	ginkgo  ./...
+
+# gen:
+#	go generate ./...
+# docker:
+#	docker build -t $(docker_registry) .
+
+# publish: docker
+#	docker push $(docker_registry)
+
+# fmt:
+#	find . -name '*.go' | while read -r f; do \
+#		gofmt -w -s "$$f"; \
+#	done
+
+# .DEFAULT_GOAL := docker
+
+# .PHONY: go-mod docker-build docker-push docker test fmt

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ SEMVER_VERSION := $(SEMVER_VERSION)$(if $(SEMVER_MINOR),.$(SEMVER_MINOR),$(error
 SEMVER_VERSION := $(SEMVER_VERSION)$(if $(SEMVER_PATCH),.$(SEMVER_PATCH),$(error Missing SEMVER_PATCH))
 SEMVER_VERSION := $(SEMVER_VERSION)$(if $(SEMVER_PRERELEASE),-$(SEMVER_PRERELEASE))
 
-.PHONY: build test require-% release-% clean show-releases
+.PHONY: distbuild build require-% release-% clean distclean show-releases
 
 build: BUILD_RULE_CMD := CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) \
 	                     go build -ldflags="$(GO_LDFLAGS) \
@@ -56,7 +56,10 @@ show-releases:
 	@ls -lA $(RELEASE_ROOT)
 	@echo ""
 
-release-all: release-clean $(RELEASES) show-releases
+release-all: release-clean distbuild $(RELEASES) show-releases
+
+distbuild:
+	mkdir -p $(RELEASE_ROOT)
 
 define build-target
 release-$(1)/$(2)-$(PROJECT): # require-VERSION
@@ -75,26 +78,3 @@ release-clean:
 distclean: clean release-clean
 
 .DEFAULT_GOAL := release-all
-
-# test:
-#	ginkgo watch ./...
-	
-# test-ci:
-#	ginkgo  ./...
-
-# gen:
-#	go generate ./...
-# docker:
-#	docker build -t $(docker_registry) .
-
-# publish: docker
-#	docker push $(docker_registry)
-
-# fmt:
-#	find . -name '*.go' | while read -r f; do \
-#		gofmt -w -s "$$f"; \
-#	done
-
-# .DEFAULT_GOAL := docker
-
-# .PHONY: go-mod docker-build docker-push docker test fmt

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,28 @@ RELEASE_ROOT   ?=releases
 DEV_TEST_BUILD =./$(PROJECT)
 TARGETS        ?=linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
 
-SEMVER_MAJOR    ?=2
-SEMVER_MINOR    ?=1
-SEMVER_PATCH    ?=0
+ifneq ($(VERSION),)
+VERSION_SPLIT:=$(subst ., ,$(VERSION))
+  ifneq ($(words $(VERSION_SPLIT)),3)
+    $(error VERSION does not 3 parts $(VERSION))
+  endif
+else
+VERSION_TAG:=$(shell git describe --tags --abbrev=0 | sed -e "s/^v//")
+VERSION_SPLIT:=$(subst ., ,$(VERSION_TAG))
+  ifneq ($(words $(VERSION_SPLIT)),3)
+    $(error VERSION_TAG  does not 3 parts |$(words VERSION_SPLIT)|$(VERSION_TAG)|$(VERSION_SPLIT)|)
+  endif
+endif
+
+IS_NOT_NUMBER:=$(shell echo $(VERSION_SPLIT) | sed -e 's/[0123456789]//g')
+
+ifneq ($(words $(IS_NOT_NUMBER)), 0)
+  $(error The version string contain non-numeric characters)
+endif
+
+SEMVER_MAJOR    ?=$(word 1,$(VERSION_SPLIT))
+SEMVER_MINOR    ?=$(word 2,$(VERSION_SPLIT))
+SEMVER_PATCH    ?=$(word 3,$(VERSION_SPLIT))
 SEMVER_PRERELEASE ?=
 SEMVER_BUILDMETA  ?=
 BUILD_DATE        :=$(shell date -u -Iseconds)
@@ -35,15 +54,15 @@ SEMVER_VERSION := $(SEMVER_VERSION)$(if $(SEMVER_MINOR),.$(SEMVER_MINOR),$(error
 SEMVER_VERSION := $(SEMVER_VERSION)$(if $(SEMVER_PATCH),.$(SEMVER_PATCH),$(error Missing SEMVER_PATCH))
 SEMVER_VERSION := $(SEMVER_VERSION)$(if $(SEMVER_PRERELEASE),-$(SEMVER_PRERELEASE))
 
-.PHONY: distbuild build require-% release-% clean distclean show-releases
+.PHONY: distbuild build require-% release-% ci-release clean distclean show-releases create-repo-index
+
+build: BUILD_GO_LDFLAGS:=-ldflags="$(GO_LDFLAGS) -X '$(GOMODULECMD).GoOs=$(GOOS)' -X '$(GOMODULECMD).GoArch=$(GOARCH)'"
 
 build: BUILD_RULE_CMD := CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) \
-	                     go build -ldflags="$(GO_LDFLAGS) \
-					     -X '$(GOMODULECMD).GoOs=$(GOOS)' \
-					     -X '$(GOMODULECMD).GoArch=$(GOARCH)'" \
-				   	     -o $(DEV_TEST_BUILD)
+	                     go build $(BUILD_GO_LDFLAGS) -o $(DEV_TEST_BUILD)
 
 build: clean
+	@echo "Building $(DEV_TEST_BUILD)"
 	$(BUILD_RULE_CMD)
 
 require-%:
@@ -58,9 +77,14 @@ show-releases:
 	@ls -lA $(RELEASE_ROOT)
 	@echo ""
 
-sha1-releases:
+ci-release: require-VERSION release-all
 
-release-all: release-clean distbuild $(RELEASES) show-releases
+release-all: release-clean distbuild $(RELEASES) create-repo-index show-releases
+
+create-repo-index: $(RELEASE_ROOT)/repo-index.yml
+
+$(RELEASE_ROOT)/repo-index.yml: $(RELEASES) generate-repo-index
+	./generate-repo-index "$(RELEASE_ROOT)" "$(PROJECT)" "$(SEMVER_VERSION)" "$(BUILD_DATE)"
 
 distbuild:
 	@mkdir -p $(RELEASE_ROOT)
@@ -74,7 +98,7 @@ release-$(1)/$(2)-$(PROJECT): RELEASE_EXECUTABLE:=$$(RELEASE_EXECUTABLE_BASE)$(i
 
 release-$(1)/$(2)-$(PROJECT): RELEASE_EXECUTABLE_SHA1:=$$(RELEASE_EXECUTABLE_BASE).sha1
 
-release-$(1)/$(2)-$(PROJECT): # require-VERSION
+release-$(1)/$(2)-$(PROJECT):
 	@echo "Building $$(PROJECT) version $$(SEMVER_VERSION) for $(1) $(2) ..."
 	@CGO_ENABLED=0 GOOS=$(1) GOARCH=$(2) go build -o $$(RELEASE_EXECUTABLE) $$(RELEASE_GO_LDFLAGS)
 	@openssl sha1 -r $$(RELEASE_EXECUTABLE) > $$(RELEASE_EXECUTABLE_SHA1)
@@ -90,4 +114,4 @@ release-clean:
 
 distclean: clean release-clean
 
-.DEFAULT_GOAL := release-all
+.DEFAULT_GOAL := ci-release

--- a/Makefile
+++ b/Makefile
@@ -68,14 +68,16 @@ distbuild:
 define build-target
 release-$(1)/$(2)-$(PROJECT): RELEASE_GO_LDFLAGS:=-ldflags="$(GO_LDFLAGS) -X '$(GOMODULECMD).GoOs=$(1)' -X '$(GOMODULECMD).GoArch=$(2)'"
 
-release-$(1)/$(2)-$(PROJECT): RELEASE_EXECUTABLE:=$(RELEASE_ROOT)/$(PROJECT)-$(SEMVER_VERSION)+$(1).$(2)$(if $(3),.$(3))$(if $(patsubst windows,,$(1)),,.exe)
+release-$(1)/$(2)-$(PROJECT): RELEASE_EXECUTABLE_BASE:=$(RELEASE_ROOT)/$(PROJECT)-$(SEMVER_VERSION)+$(1).$(2)$(if $(3),.$(3))
 
-release-$(1)/$(2)-$(PROJECT): RELEASE_SHA1_FILE:=$(RELEASE_ROOT)/$(PROJECT)-$(SEMVER_VERSION)+$(1).$(2)$(if $(3),.$(3)).sha1
+release-$(1)/$(2)-$(PROJECT): RELEASE_EXECUTABLE:=$$(RELEASE_EXECUTABLE_BASE)$(if $(patsubst windows,,$(1)),,.exe)
+
+release-$(1)/$(2)-$(PROJECT): RELEASE_EXECUTABLE_SHA1:=$$(RELEASE_EXECUTABLE_BASE).sha1
 
 release-$(1)/$(2)-$(PROJECT): # require-VERSION
 	@echo "Building $$(PROJECT) version $$(SEMVER_VERSION) for $(1) $(2) ..."
 	@CGO_ENABLED=0 GOOS=$(1) GOARCH=$(2) go build -o $$(RELEASE_EXECUTABLE) $$(RELEASE_GO_LDFLAGS)
-	@openssl sha1 -r $$(RELEASE_EXECUTABLE) > $$(RELEASE_SHA1_FILE)
+	@openssl sha1 -r $$(RELEASE_EXECUTABLE) > $$(RELEASE_EXECUTABLE_SHA1)
 endef
 
 $(foreach target,$(TARGETS), $(eval $(call build-target,$(word 1, $(subst /, ,$(target))),$(word 2, $(subst /, ,$(target))),$(SEMVER_BUILDMETA))))

--- a/TODO
+++ b/TODO
@@ -5,3 +5,9 @@
 
 2. Cleanup building
 3. Add pipelining
+
+
+# One way to get values from the executable that is not stripped
+use GoReSym
+github.com/mandiant/GoReSym.git
+../../Tools/GoReSym/GoReSym  releases/cf-targets-plugin-2.1.0+windows.amd64.exe | jq '.BuildInfo.Settings|.[]|select(.Key=="-ldflags").Value'

--- a/cf_targets.go
+++ b/cf_targets.go
@@ -54,11 +54,16 @@ func (*RealOS) WriteFile(path string, content []byte, mode realos.FileMode) erro
 }
 
 var os OS
-var Major string
-var Minor string
-var Patch string
-var Prrls string // prerelease
-var Build string
+var SemVerMajor string
+var SemVerMinor string
+var SemVerPatch string
+var SemVerPrerelease string
+var SemVerBuild string
+var BuildDate   string
+var BuildVcsUrl string
+var BuildVcsId   string
+var BuildVcsIdDate string
+
 var GoArch string
 var GoOs string
 
@@ -87,9 +92,9 @@ func (c *TargetsPlugin) GetMetadata() plugin.PluginMetadata {
 	return plugin.PluginMetadata{
 		Name: "cf-targets",
 		Version: plugin.VersionType{
-			Major: getIntOrPanic(Major),
-			Minor: getIntOrPanic(Minor),
-			Build: getIntOrPanic(Patch),
+			Major: getIntOrPanic(SemVerMajor),
+			Minor: getIntOrPanic(SemVerMinor),
+			Build: getIntOrPanic(SemVerPatch),
 		},
 		Commands: []plugin.Command{
 			{
@@ -130,7 +135,38 @@ func (c *TargetsPlugin) GetMetadata() plugin.PluginMetadata {
 	}
 }
 
+func createSemVer(major, minor, patch, prerelease, build string)( string) {
+	p1 := strings.TrimSpace(major)
+	p2 := strings.TrimSpace(minor)
+	p3 := strings.TrimSpace(patch)
+	p4 := strings.TrimSpace(prerelease)
+	p5 := strings.TrimSpace(build)
+	if p1 == "" || p2 == "" || p3 == "" {
+		panic(fmt.Sprintf("Semanic version is missing one of its parts: %s.%s.%s", p1,p2,p3)) 
+	}
+
+	sv := strings.Join([]string{p1,p2,p3},".")
+	if p4 != "" {
+		sv += "-" + p4;
+	}
+	if p5 != "" {
+		sv += "+" + p5;
+	}
+	return sv
+}
+
+
 func main() {
+	args := realos.Args[1:]
+	if len(args) == 0 {
+		sv := createSemVer(SemVerMajor, SemVerMinor, SemVerPatch, SemVerPrerelease,SemVerBuild)
+		f := "%13v %v\n"
+	    fmt.Printf(f, "Version:",sv)
+	    fmt.Printf(f, "Build Date:", BuildDate)
+	    fmt.Printf(f, "VCS Url:", BuildVcsUrl)
+	    fmt.Printf(f, "VCS Id:", BuildVcsId)
+	    fmt.Printf(f, "VCS Id Date:", BuildVcsIdDate)
+    }
 	os = &RealOS{}
 	plugin.Start(newTargetsPlugin())
 }

--- a/cf_targets.go
+++ b/cf_targets.go
@@ -5,8 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"strconv"
+	"strings"
 
 	realio "io/ioutil"
 	realos "os"
@@ -59,11 +59,10 @@ var SemVerMinor string
 var SemVerPatch string
 var SemVerPrerelease string
 var SemVerBuild string
-var BuildDate   string
+var BuildDate string
 var BuildVcsUrl string
-var BuildVcsId   string
+var BuildVcsId string
 var BuildVcsIdDate string
-
 var GoArch string
 var GoOs string
 
@@ -74,7 +73,6 @@ func getIntOrPanic(toInt string) int {
 	}
 	return theInt
 }
-
 
 func newTargetsPlugin() *TargetsPlugin {
 	configPath, _ := confighelpers.DefaultFilePath()
@@ -135,38 +133,52 @@ func (c *TargetsPlugin) GetMetadata() plugin.PluginMetadata {
 	}
 }
 
-func createSemVer(major, minor, patch, prerelease, build string)( string) {
+func createBuildMeta(buildOs, buildArch, build string) string {
+	p1 := strings.TrimSpace(buildOs)
+	p2 := strings.TrimSpace(buildArch)
+	p3 := strings.TrimSpace(build)
+	if p1 == "" || p2 == "" {
+		panic(fmt.Sprintf("Go meta data is missing one of its parts: %s, %s ", p1, p2))
+	}
+	b := strings.Join([]string{p1, p2}, ".")
+	if p3 != "" {
+		b += "." + p3
+	}
+	return b
+}
+
+func createSemVer(major, minor, patch, prerelease, build string) string {
 	p1 := strings.TrimSpace(major)
 	p2 := strings.TrimSpace(minor)
 	p3 := strings.TrimSpace(patch)
 	p4 := strings.TrimSpace(prerelease)
 	p5 := strings.TrimSpace(build)
 	if p1 == "" || p2 == "" || p3 == "" {
-		panic(fmt.Sprintf("Semanic version is missing one of its parts: %s.%s.%s", p1,p2,p3)) 
+		panic(fmt.Sprintf("Semanic version is missing one of its parts: %s.%s.%s", p1, p2, p3))
 	}
 
-	sv := strings.Join([]string{p1,p2,p3},".")
+	sv := strings.Join([]string{p1, p2, p3}, ".")
 	if p4 != "" {
-		sv += "-" + p4;
+		sv += "-" + p4
 	}
 	if p5 != "" {
-		sv += "+" + p5;
+		sv += "+" + p5
 	}
 	return sv
 }
 
-
 func main() {
 	args := realos.Args[1:]
 	if len(args) == 0 {
-		sv := createSemVer(SemVerMajor, SemVerMinor, SemVerPatch, SemVerPrerelease,SemVerBuild)
+		bm := createBuildMeta(GoOs, GoArch, SemVerBuild)
+		sv := createSemVer(SemVerMajor, SemVerMinor, SemVerPatch, SemVerPrerelease, bm)
 		f := "%13v %v\n"
-	    fmt.Printf(f, "Version:",sv)
-	    fmt.Printf(f, "Build Date:", BuildDate)
-	    fmt.Printf(f, "VCS Url:", BuildVcsUrl)
-	    fmt.Printf(f, "VCS Id:", BuildVcsId)
-	    fmt.Printf(f, "VCS Id Date:", BuildVcsIdDate)
-    }
+		fmt.Printf(f, "Version:", sv)
+		fmt.Printf(f, "Build Date:", BuildDate)
+		fmt.Printf(f, "VCS Url:", BuildVcsUrl)
+		fmt.Printf(f, "VCS Id:", BuildVcsId)
+		fmt.Printf(f, "VCS Id Date:", BuildVcsIdDate)
+	}
 	os = &RealOS{}
 	plugin.Start(newTargetsPlugin())
 }

--- a/cf_targets_test.go
+++ b/cf_targets_test.go
@@ -3,9 +3,9 @@ package main
 import (
 	realos "os"
 
-	fakes "code.cloudfoundry.org/cli/plugin/pluginfakes"
 	. "code.cloudfoundry.org/cli/cf/util/testhelpers/io"
 	. "code.cloudfoundry.org/cli/cf/util/testhelpers/matchers"
+	fakes "code.cloudfoundry.org/cli/plugin/pluginfakes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/generate-repo-index
+++ b/generate-repo-index
@@ -1,0 +1,35 @@
+RELEASE_ROOT="${1}"
+PROJECT="${2}"
+SEMVER_VERSION="${3}"
+BUILD_DATE="${4}"
+
+cat <<EOF >${RELEASE_ROOT}/repo-index.yml 
+plugins:
+- authors:
+  - contact: gwestenberg@pivotal.io
+    homepage: http://github.com/guidowb
+    name: Guido Westenberg
+  - contact: nabramovitz@fivetwenty.io
+    homepage: http://github.com/norman-abramovitz
+    name: Norman Abramovitz
+  binaries:
+  - checksum: $(cat ${RELEASE_ROOT}/${PROJECT}*darwin.amd64*.sha1)) 
+    platform: osx-amd64
+    url: http://github.com/norman-abramovitz/cf-targets-plugin/raw/${SEMVER_VERSION}/bin/osx-amd64/cf-targets-plugin
+  - checksum: $(cat ${RELEASE_ROOT}/${PROJECT}*darwin.arm64*.sha1)) 
+    platform: osx-arm64
+    url: http://github.com/norman-abramovitz/cf-targets-plugin/raw/${SEMVER_VERSION}/bin/osx-arm64/cf-targets-plugin
+  - checksum: $(cat ${RELEASE_ROOT}/${PROJECT}*windows.amd64*.sha1)) 
+    platform: win64
+    url: http://github.com/norman-abramovitz/cf-targets-plugin/raw/${SEMVER_VERSION}/bin/win64/cf-targets-plugin.exe
+  - checksum: $(cat ${RELEASE_ROOT}/${PROJECT}*linux.amd64*.sha1)) 
+    platform: linux64
+    url: http://github.com/norman-abramovitz/cf-targets-plugin/raw/${SEMVER_VERSION}/bin/linux64/cf-targets-plugin
+  company: null
+  created: "2015-04-17"
+  description: Easily manage multiple CF targets
+  homepage: http://github.com/norman-abramovitz/cf-targets-plugin
+  name: Targets
+  updated: ${BUILD_DATE}
+  version: ${SEMVER_VERSION}
+EOF


### PR DESCRIPTION
Use GMake for building than the shell script. 

Ability to do automation or manual releases

- The **ci-release** target is meant for automation releases
- Release artifacts are stored in the **releases** directory
- Local builds can use the **build** target
- The **release-all** target is meant for manual releases
- The Make VERSION variable or latest VCS tag can be used to set the version value
- The VERSION value must match the following regex (\d+)\.(\d+)\.(\d+)
- The version tag may have a leading 'v' character.
- The MAKE SEMVER_PRERELEASE variable can be set as defined by the [semver convention][https://semver.org]
- The MAKE SEMVER_BUILDMETA variable can be set as defined by the [semver convention][https://semver.org]
- For Go programs, the GOOS and GOARCH variables are added by default to the semantic version build section
- The MAKE BUILD_DATE variable contains the build date in ISO 8601 format
- The MAKE BUILD_VCS_URL variable contains the version control system url for the code being built.
- The MAKE BUILD_VCS_ID variable contains the version control system unique id for the latest code changes.
- The MAKE BUILD_VCS_ID_DATE variable contains the version control system lastest updated datetime for the particular  code changes.
- For Go Programs, the BUILD_* variables should be embedded into the executable.

The repo-index.yaml file is built using the **_generate-repo-index_** and is stored with the rest of the artifacts.